### PR TITLE
Enhance focus page layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Focus</title>
   <link rel="icon" href="favicon.ico" type="image/x-icon">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@600&display=swap" rel="stylesheet">
@@ -13,32 +14,151 @@
     }
 
     body {
-      background: linear-gradient(135deg, #0f2027, #203a43, #2c5364);
-      height: 100vh;
+      background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.08), transparent 35%),
+                  radial-gradient(circle at 80% 10%, rgba(255, 255, 255, 0.05), transparent 30%),
+                  linear-gradient(135deg, #0f2027, #203a43, #2c5364);
+      min-height: 100vh;
       display: flex;
       align-items: center;
       justify-content: center;
-      color: #ffffff;
+      color: #e7f3ff;
       font-family: 'Inter', sans-serif;
       text-align: center;
+      padding: 24px;
+    }
+
+    main {
+      max-width: 720px;
+      width: 100%;
+    }
+
+    .card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 20px;
+      padding: 48px 40px;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+      backdrop-filter: blur(8px);
+      transition: transform 250ms ease, box-shadow 250ms ease, border-color 250ms ease;
+    }
+
+    .card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 26px 70px rgba(0, 0, 0, 0.45);
+      border-color: rgba(255, 255, 255, 0.16);
     }
 
     h1 {
-      font-size: 5rem;
-      letter-spacing: 0.15em;
+      font-size: clamp(2.5rem, 5vw, 4.25rem);
+      letter-spacing: 0.08em;
       animation: pulse 3s infinite;
-      text-shadow: 0 0 20px rgba(255, 255, 255, 0.1);
+      text-shadow: 0 0 25px rgba(255, 255, 255, 0.14);
+      line-height: 1.1;
+    }
+
+    p {
+      margin-top: 16px;
+      font-size: clamp(1.05rem, 2.5vw, 1.2rem);
+      color: #d6e7ff;
+      line-height: 1.6;
+    }
+
+    .actions {
+      margin-top: 28px;
+      display: flex;
+      gap: 14px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .button {
+      appearance: none;
+      border: none;
+      border-radius: 14px;
+      padding: 14px 22px;
+      font-size: 1rem;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      color: #0f2027;
+      background: linear-gradient(135deg, #8ef1c7, #4ad1ff);
+      box-shadow: 0 10px 25px rgba(74, 209, 255, 0.35);
+      transition: transform 200ms ease, box-shadow 200ms ease, filter 200ms ease;
+    }
+
+    .button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 14px 28px rgba(74, 209, 255, 0.45);
+      filter: brightness(1.02);
+    }
+
+    .button.secondary {
+      background: rgba(255, 255, 255, 0.12);
+      color: #e7f3ff;
+      box-shadow: none;
+      border: 1px solid rgba(255, 255, 255, 0.14);
+    }
+
+    .button.secondary:hover {
+      border-color: rgba(255, 255, 255, 0.28);
     }
 
     @keyframes pulse {
-      0% { opacity: 0.8; transform: scale(1); }
-      50% { opacity: 1; transform: scale(1.03); }
-      100% { opacity: 0.8; transform: scale(1); }
+      0% { opacity: 0.85; transform: scale(1); }
+      50% { opacity: 1; transform: scale(1.02); }
+      100% { opacity: 0.85; transform: scale(1); }
+    }
+
+    .affirmations {
+      margin-top: 24px;
+      display: flex;
+      gap: 12px;
+      justify-content: center;
+      flex-wrap: wrap;
+      color: #c7ddf7;
+      font-size: 0.95rem;
+      letter-spacing: 0.02em;
+    }
+
+    .pill {
+      padding: 10px 14px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 999px;
+      backdrop-filter: blur(6px);
+    }
+
+    @media (max-width: 480px) {
+      .card {
+        padding: 36px 26px;
+      }
+
+      h1 {
+        letter-spacing: 0.04em;
+      }
+
+      .actions {
+        gap: 10px;
+      }
     }
   </style>
 </head>
 <body>
-  <h1>🍃<br>
-  Stay focus, be present!</h1>
+  <main>
+    <section class="card" aria-label="Focus prompt">
+      <h1>🍃<br>
+      Stay focused, be present.</h1>
+      <p>Take a deep breath, soften your gaze, and give your next task your full attention. A few calm minutes go a long way.</p>
+      <div class="actions">
+        <button class="button" type="button">Start a 5-minute focus</button>
+        <button class="button secondary" type="button">Set a gentle reminder</button>
+      </div>
+      <div class="affirmations" aria-hidden="true">
+        <span class="pill">Breathe in. Breathe out.</span>
+        <span class="pill">Single-task > multitask</span>
+        <span class="pill">Progress, not perfection</span>
+      </div>
+    </section>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add responsive meta viewport and refreshed layout with glassmorphism styling
- improve focus prompt copy, add supportive affirmations, and responsive typography
- introduce primary and secondary call-to-action buttons for focus sessions and reminders

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941a92bfec4832aafbdb556f1fbcc94)